### PR TITLE
history.exists() fix

### DIFF
--- a/extension/history.js
+++ b/extension/history.js
@@ -34,7 +34,10 @@ module.exports = {
         channel = channel.toLowerCase();
 
         var exists = false;
-        if (hist[channel]) {
+        if (!hist.hasOwnProperty(channel)) {
+            hist[channel] = jsonStorage.getItem(channel) || [];
+        }        
+        if (hist[channel].length > 0) {
             if (typeof months !== 'undefined') {
                 exists = hist[channel].some(function(currentValue) {
                     if (currentValue.username === username && currentValue.months === months) return true;


### PR DESCRIPTION
Fixed exists() method in history.js to prevent a false sub event to be triggered when NodeCG (re)starts